### PR TITLE
fix(jsdoc): remove requirement for return statemnt

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const ERROR = 2;
 
 const rules = {
   'no-param-reassign': [ERROR, { props: false }],
-  'valid-jsdoc': [ERROR],
+  'valid-jsdoc': [ERROR, { requireReturn: false }],
   complexity: [ERROR, 6],
 };
 


### PR DESCRIPTION
when there's not return statement in function, there doesn't need to be one in the jsdoc