### PR TITLE
fix(ci): switch npm publish to OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,16 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run: .circleci/setup-git.sh > /dev/null 2>&1
-      - run: npx semantic-release
+      - run:
+          name: Get npm OIDC token
+          command: |
+            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            echo "export NPM_ID_TOKEN=$NPM_ID_TOKEN" >> "$BASH_ENV"
+      - run:
+          name: release
+          command: npx semantic-release
+          environment:
+            NPM_CONFIG_PROVENANCE: "true"
 
 workflows:
   test_and_release:

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     ],
     "verifyConditions": [
       "@semantic-release/changelog",
-      "@semantic-release/npm",
       "@semantic-release/git",
       "@semantic-release/github"
     ]


### PR DESCRIPTION
## Summary

Replaces the static `NPM_TOKEN` in the CircleCI Release context with npm OIDC trusted publishing. No token rotation required going forward.

**How it works:**
- Before `semantic-release` runs, the job calls `circleci run oidc get` to get a short-lived OIDC JWT scoped to `npm:registry.npmjs.org`
- That token is exported as `NPM_ID_TOKEN`; npm CLI exchanges it automatically for a publish credential at runtime
- `NPM_CONFIG_PROVENANCE=true` attaches a provenance attestation to each publish
- `@semantic-release/npm` is removed from `verifyConditions` because its auth check requires `NPM_TOKEN` (which is no longer set); the publish step itself works fine via `NPM_ID_TOKEN`

## Setup required before merging

- [ ] CircleCI is already configured as a trusted publisher on the `@mi11er/eslint-config` package (confirmed)
- [ ] Remove `NPM_TOKEN` from the CircleCI Release context after this merges (it will no longer be used)

## Test plan

- [ ] Merge this PR
- [ ] Confirm CircleCI release job runs, publishes v3.0.0 to npm, and creates a GitHub release
- [ ] Verify the published package has a provenance attestation on npmjs.com