### PR TITLE
fix(ci): bypass @semantic-release/npm auth using exec + npm publish directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,6 @@ jobs:
       - run:
           name: release
           command: npx semantic-release
-          environment:
-            NPM_CONFIG_PROVENANCE: "true"
 
 workflows:
   test_and_release:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^12.0.8",
-        "@semantic-release/npm": "^13.1.5",
         "commitizen": "4.3.1",
         "cz-conventional-changelog": "3.3.0",
         "eslint": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "prepare": [
       "@semantic-release/changelog",
       {
-        "path": "@semantic-release/npm",
-        "tarballDir": "release"
+        "path": "@semantic-release/exec",
+        "cmd": "npm --no-git-tag-version version ${nextRelease.version} && npm pack --pack-destination release"
       },
       {
         "path": "@semantic-release/exec",
@@ -67,7 +67,10 @@
       }
     ],
     "publish": [
-      "@semantic-release/npm",
+      {
+        "path": "@semantic-release/exec",
+        "cmd": "npm publish release/*.tgz --provenance"
+      },
       {
         "path": "@semantic-release/github",
         "assets": [
@@ -80,7 +83,6 @@
     ],
     "verifyConditions": [
       "@semantic-release/changelog",
-      "@semantic-release/npm",
       "@semantic-release/git",
       "@semantic-release/github"
     ]
@@ -95,7 +97,6 @@
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^12.0.8",
-    "@semantic-release/npm": "^13.1.5",
     "commitizen": "4.3.1",
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^10.0.0",


### PR DESCRIPTION
## Problem

`@semantic-release/npm` does not support CircleCI OIDC trusted publishing — it only detects OIDC for GitHub Actions and GitLab. With `NPM_TOKEN` removed from the Release context, it throws `ENONPMTOKEN` regardless of `NPM_ID_TOKEN` being set.

Upstream tracking issue: semantic-release/npm#1121

## Workaround

Replace `@semantic-release/npm` with `@semantic-release/exec` calls that invoke `npm` directly. The npm CLI handles `NPM_ID_TOKEN` natively without any auth pre-check:

- **prepare**: `npm --no-git-tag-version version ${nextRelease.version} && npm pack --pack-destination release`
- **publish**: `npm publish release/*.tgz --provenance`

Remove `@semantic-release/npm` from `devDependencies` and `verifyConditions`. Drop `NPM_CONFIG_PROVENANCE` from the CircleCI env — `--provenance` is now passed explicitly.

## Revert plan

Once semantic-release/npm#1121 is resolved, revert this in favour of `@semantic-release/npm` with native OIDC support.