### PR TITLE
fix(ci): mkdir -p release before npm pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "@semantic-release/changelog",
       {
         "path": "@semantic-release/exec",
-        "cmd": "npm --no-git-tag-version version ${nextRelease.version} && npm pack --pack-destination release"
+        "cmd": "npm --no-git-tag-version version ${nextRelease.version} && mkdir -p release && npm pack --pack-destination release"
       },
       {
         "path": "@semantic-release/exec",


### PR DESCRIPTION
The `release/` directory is gitignored so it doesn't exist in the CI workspace when `npm pack` runs. Add `mkdir -p release` to the prepare command before packing.