### PR TITLE
fix(ci): checkout fresh on release job to avoid behind-remote race condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,15 +25,17 @@ jobs:
       - run:
           name: test
           command: npm test
-      - persist_to_workspace:
-          root: ~/project
-          paths:
-            - repo
   release:
     executor: node
     steps:
-      - attach_workspace:
-          at: ~/project
+      - checkout
+      - restore_cache:
+          keys:
+            - v3-dependencies-{{ checksum "package-lock.json" }}
+            - v3-dependencies-
+      - run:
+          name: install-npm-dependencies
+          command: npm ci
       - run: .circleci/setup-git.sh > /dev/null 2>&1
       - run:
           name: Get npm OIDC token


### PR DESCRIPTION
## Summary

- Replaces `attach_workspace` in the release job with a fresh `checkout` + cache restore
- Fixes a race condition where Renovate (or any push to master) between the test and release jobs causes semantic-release to skip the release with "local branch master is behind the remote one"
- The `persist_to_workspace` / `attach_workspace` steps are removed since the release job no longer needs them

## Root cause

The test job persists the workspace at the commit it checked out. If master advances before the release job runs, semantic-release's pre-flight check sees the local branch as behind origin and exits without publishing. A fresh checkout always gets the current HEAD.

## Test plan

- [ ] Pipeline triggers on merge and release job runs semantic-release successfully
- [ ] v3.0.0 publishes to npm