### PR TITLE
fix(ci): use ./ prefix on npm publish tarball path

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "publish": [
       {
         "path": "@semantic-release/exec",
-        "cmd": "npm publish release/*.tgz --provenance"
+        "cmd": "npm publish ./release/*.tgz --provenance"
       },
       {
         "path": "@semantic-release/github",


### PR DESCRIPTION
## Summary

- Change `npm publish release/*.tgz` to `npm publish ./release/*.tgz`

## Root cause

Without the `./` prefix, npm interprets `release/mi11er-eslint-config-3.0.0.tgz` as a GitHub `user/repo` shorthand (`release` = user, `mi11er-eslint-config-3.0.0.tgz` = repo) and attempts an SSH clone instead of publishing the local tarball.