### PR TITLE
fix(ci): remove --provenance flag from npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "publish": [
       {
         "path": "@semantic-release/exec",
-        "cmd": "npm publish ./release/*.tgz --provenance"
+        "cmd": "npm publish ./release/*.tgz"
       },
       {
         "path": "@semantic-release/github",


### PR DESCRIPTION
## Summary

- Remove `--provenance` from `npm publish ./release/*.tgz`

## Root cause

npm's `--provenance` flag for SLSA provenance attestation only supports GitHub Actions and GitLab CI. CircleCI is not a supported provider, causing the publish step to fail with `EUSAGE: Automatic provenance generation not supported for provider: CircleCI`.

The OIDC trusted publishing (authentication via `NPM_ID_TOKEN`) is unaffected — that's separate from provenance attestation.