### PR TITLE
fix: mark React-only peer deps as optional via peerDependenciesMeta

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,5 +126,16 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^7.0.0",
     "eslint-plugin-security": "^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-jsx-a11y": {
+      "optional": true
+    },
+    "eslint-plugin-react": {
+      "optional": true
+    },
+    "eslint-plugin-react-hooks": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `peerDependenciesMeta` to mark `eslint-plugin-jsx-a11y`, `eslint-plugin-react`, and `eslint-plugin-react-hooks` as optional peer dependencies
- These plugins are only consumed by the `./react` subpath export, so non-React consumers should not be required to install them
- Eliminates the ESLint 10 peer conflict caused by `jsx-a11y@6` not declaring `^10` in its peer range, removing the need for `legacy-peer-deps=true` workarounds (see mi11er-net/renovate-config#352)

## Test plan

- [ ] Non-React consumer: install with `npm install @mi11er/eslint-config` on ESLint 10 — no peer dep warnings for the three React plugins
- [ ] React consumer: install with React plugins explicitly — still works correctly
- [ ] Confirm `npm pack` output includes the updated `package.json`

Closes #245